### PR TITLE
react-router-dom updated to v6 thus some changes are necessary

### DIFF
--- a/template/fullstack/auth/client/src/App.js
+++ b/template/fullstack/auth/client/src/App.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { Switch } from "react-router-dom";
+import { Routes } from "react-router-dom";
 import LoadingComponent from "./components/Loading";
 import Navbar from "./components/Navbar/Navbar";
 import HomePage from "./pages/HomePage";
@@ -84,27 +84,27 @@ class App extends React.Component {
     return (
       <div className="App">
         <Navbar handleLogout={this.handleLogout} user={this.state.user} />
-        <Switch>
-          <NormalRoute exact path={PATHS.HOMEPAGE} component={HomePage} />
+        <Routes>
+          <NormalRoute exact path={PATHS.HOMEPAGE} element={<HomePage />} />
           <NormalRoute
             exact
             path={PATHS.SIGNUPPAGE}
             authenticate={this.authenticate}
-            component={Signup}
+            element={<Signup />}
           />
           <NormalRoute
             exact
             path={PATHS.LOGINPAGE}
             authenticate={this.authenticate}
-            component={LogIn}
+            element={<LogIn />}
           />
           <ProtectedRoute
             exact
             path={PATHS.PROTECTEDPAGE}
-            component={ProtectedPage}
+            element={<ProtectedPage />}
             user={this.state.user}
           />
-        </Switch>
+        </Routes>
       </div>
     );
   }

--- a/template/fullstack/auth/client/src/pages/LogIn.jsx
+++ b/template/fullstack/auth/client/src/pages/LogIn.jsx
@@ -1,5 +1,6 @@
 import React, { Component } from "react";
 import { login } from "../services/auth";
+import { Navigate } from "react-router-dom";
 import "./Signup";
 import * as PATHS from "../utils/paths";
 import * as USER_HELPERS from "../utils/userToken";
@@ -31,7 +32,7 @@ export default class Login extends Component {
       }
       USER_HELPERS.setUserToken(res.data.accessToken);
       this.props.authenticate(res.data.user);
-      this.props.history.push(PATHS.HOMEPAGE);
+      <Navigate to={PATHS.HOMEPAGE} />;
     });
   };
 

--- a/template/fullstack/auth/client/src/pages/Signup.jsx
+++ b/template/fullstack/auth/client/src/pages/Signup.jsx
@@ -1,5 +1,6 @@
 import React, { Component } from "react";
 import { signup } from "../services/auth";
+import { Navigate } from "react-router-dom";
 import "./auth.css";
 import * as PATHS from "../utils/paths";
 import * as USER_HELPERS from "../utils/userToken";
@@ -32,7 +33,7 @@ export default class Signup extends Component {
       }
       USER_HELPERS.setUserToken(res.data.accessToken);
       this.props.authenticate(res.data.user);
-      this.props.history.push(PATHS.HOMEPAGE);
+      <Navigate to={PATHS.HOMEPAGE} />;
     });
   };
 

--- a/template/fullstack/auth/client/src/routing-components/NormalRoute.jsx
+++ b/template/fullstack/auth/client/src/routing-components/NormalRoute.jsx
@@ -1,15 +1,17 @@
 import React from "react";
-import { Route } from "react-router-dom";
+import { Route, Routes } from "react-router-dom";
 
 // this kind of component is a `wrapper` around the React router dom Route where we immediately pass every single prop down. Instead of writing things with the render
 const NormalRoute = ({ exact, to, path, component, ...componentProps }) => {
   const Component = component;
   return (
-    <Route
-      exact={exact}
-      path={path || to}
-      render={(props) => <Component {...componentProps} {...props} />}
-    />
+    <Routes>
+      <Route
+        exact={exact}
+        path={path || to}
+        element={<Component {...componentProps} {...props} />}
+      />
+    </Routes>
   );
 };
 

--- a/template/fullstack/auth/client/src/routing-components/ProtectedRoute.jsx
+++ b/template/fullstack/auth/client/src/routing-components/ProtectedRoute.jsx
@@ -13,7 +13,7 @@ const ProtectedRoute = ({
 }) => {
   const Component = component;
   if (!user) {
-    return <Redirect to={PATHS.LOGINPAGE} />;
+    return <Navigate to={PATHS.LOGINPAGE} />;
   }
   return (
     <Route

--- a/template/fullstack/auth/client/src/routing-components/ProtectedRoute.jsx
+++ b/template/fullstack/auth/client/src/routing-components/ProtectedRoute.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Route, Redirect } from "react-router-dom";
+import { Routes, Route, Navigate } from "react-router-dom";
 import * as PATHS from "../utils/paths";
 
 // the protected route component must take a user in order to check if the user is authenticated or not. If not moves the user to the login page
@@ -16,13 +16,13 @@ const ProtectedRoute = ({
     return <Navigate to={PATHS.LOGINPAGE} />;
   }
   return (
-    <Route
-      exact={exact}
-      path={path || to}
-      render={(props) => (
-        <Component {...componentProps} {...props} user={user} />
-      )}
-    />
+    <Routes>
+      <Route
+        exact={exact}
+        path={path || to}
+        element={<Component {...componentProps} {...props} user={user} />}
+      />
+    </Routes>
   );
 };
 

--- a/template/fullstack_hooks/auth/client/src/App.js
+++ b/template/fullstack_hooks/auth/client/src/App.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { Switch } from "react-router-dom";
+import { Routes } from "react-router-dom";
 import LoadingComponent from "./components/Loading";
 import Navbar from "./components/Navbar/Navbar";
 import HomePage from "./pages/HomePage";
@@ -59,27 +59,27 @@ export default function App() {
   return (
     <div className="App">
       <Navbar handleLogout={handleLogout} user={user} />
-      <Switch>
-        <NormalRoute exact path={PATHS.HOMEPAGE} component={HomePage} />
+      <Routes>
+        <NormalRoute exact path={PATHS.HOMEPAGE} element={HomePage} />
         <NormalRoute
           exact
           path={PATHS.SIGNUPPAGE}
           authenticate={authenticate}
-          component={Signup}
+          element={Signup}
         />
         <NormalRoute
           exact
           path={PATHS.LOGINPAGE}
           authenticate={authenticate}
-          component={LogIn}
+          element={LogIn}
         />
         <ProtectedRoute
           exact
           path={PATHS.PROTECTEDPAGE}
-          component={ProtectedPage}
+          element={ProtectedPage}
           user={user}
         />
-      </Switch>
+      </Routes>
     </div>
   );
 }

--- a/template/fullstack_hooks/auth/client/src/pages/LogIn.jsx
+++ b/template/fullstack_hooks/auth/client/src/pages/LogIn.jsx
@@ -12,6 +12,7 @@ export default function LogIn({ authenticate }) {
   });
   const { username, password } = form;
   const [error, setError] = useState(null);
+  const navigate = useNavigate();
 
   function handleInputChange(event) {
     const { name, value } = event.target;
@@ -20,9 +21,7 @@ export default function LogIn({ authenticate }) {
   }
 
   function handleFormSubmission(event) {
-    const navigate = useNavigate();
     event.preventDefault();
-
     const credentials = {
       username,
       password,

--- a/template/fullstack_hooks/auth/client/src/pages/LogIn.jsx
+++ b/template/fullstack_hooks/auth/client/src/pages/LogIn.jsx
@@ -1,10 +1,11 @@
 import React, { useState } from "react";
 import { login } from "../services/auth";
+import { Navigate } from "react-router-dom";
 import "./Signup";
 import * as PATHS from "../utils/paths";
 import * as USER_HELPERS from "../utils/userToken";
 
-export default function LogIn({ authenticate, history }) {
+export default function LogIn({ authenticate }) {
   const [form, setForm] = useState({
     username: "",
     password: "",
@@ -31,7 +32,7 @@ export default function LogIn({ authenticate, history }) {
       }
       USER_HELPERS.setUserToken(res.data.accessToken);
       authenticate(res.data.user);
-      history.push(PATHS.HOMEPAGE);
+      <Navigate to={PATHS.HOMEPAGE} />;
     });
   }
 

--- a/template/fullstack_hooks/auth/client/src/pages/LogIn.jsx
+++ b/template/fullstack_hooks/auth/client/src/pages/LogIn.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { login } from "../services/auth";
-import { Navigate } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import "./Signup";
 import * as PATHS from "../utils/paths";
 import * as USER_HELPERS from "../utils/userToken";
@@ -20,6 +20,7 @@ export default function LogIn({ authenticate }) {
   }
 
   function handleFormSubmission(event) {
+    const navigate = useNavigate();
     event.preventDefault();
 
     const credentials = {
@@ -32,7 +33,7 @@ export default function LogIn({ authenticate }) {
       }
       USER_HELPERS.setUserToken(res.data.accessToken);
       authenticate(res.data.user);
-      <Navigate to={PATHS.HOMEPAGE} />;
+      navigate(PATHS.HOMEPAGE);
     });
   }
 

--- a/template/fullstack_hooks/auth/client/src/pages/Signup.jsx
+++ b/template/fullstack_hooks/auth/client/src/pages/Signup.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { signup } from "../services/auth";
-import { Navigate } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import "./auth.css";
 import * as PATHS from "../utils/paths";
 import * as USER_HELPERS from "../utils/userToken";
@@ -19,6 +19,7 @@ export default function Signup({ authenticate }) {
   }
 
   function handleFormSubmission(event) {
+    const navigate = useNavigate();
     event.preventDefault();
     const credentials = {
       username,
@@ -35,7 +36,7 @@ export default function Signup({ authenticate }) {
       // successful signup
       USER_HELPERS.setUserToken(res.data.accessToken);
       authenticate(res.data.user);
-      <Navigate to={PATHS.HOMEPAGE} />;
+      navigate(PATHS.HOMEPAGE);
     });
   }
 

--- a/template/fullstack_hooks/auth/client/src/pages/Signup.jsx
+++ b/template/fullstack_hooks/auth/client/src/pages/Signup.jsx
@@ -1,10 +1,11 @@
 import React, { useState } from "react";
 import { signup } from "../services/auth";
+import { Navigate } from "react-router-dom";
 import "./auth.css";
 import * as PATHS from "../utils/paths";
 import * as USER_HELPERS from "../utils/userToken";
 
-export default function Signup({ authenticate, history }) {
+export default function Signup({ authenticate }) {
   const [form, setForm] = useState({
     username: "",
     password: "",
@@ -34,7 +35,7 @@ export default function Signup({ authenticate, history }) {
       // successful signup
       USER_HELPERS.setUserToken(res.data.accessToken);
       authenticate(res.data.user);
-      history.push(PATHS.HOMEPAGE);
+      <Navigate to={PATHS.HOMEPAGE} />;
     });
   }
 

--- a/template/fullstack_hooks/auth/client/src/pages/Signup.jsx
+++ b/template/fullstack_hooks/auth/client/src/pages/Signup.jsx
@@ -12,6 +12,7 @@ export default function Signup({ authenticate }) {
   });
   const { username, password } = form;
   const [error, setError] = useState(null);
+  const navigate = useNavigate();
 
   function handleInputChange(event) {
     const { name, value } = event.target;
@@ -19,7 +20,6 @@ export default function Signup({ authenticate }) {
   }
 
   function handleFormSubmission(event) {
-    const navigate = useNavigate();
     event.preventDefault();
     const credentials = {
       username,

--- a/template/fullstack_hooks/auth/client/src/routing-components/NormalRoute.jsx
+++ b/template/fullstack_hooks/auth/client/src/routing-components/NormalRoute.jsx
@@ -1,15 +1,17 @@
 import React from "react";
-import { Route } from "react-router-dom";
+import { Route, Routes } from "react-router-dom";
 
 // this kind of component is a `wrapper` around the React router dom Route where we immediately pass every single prop down. Instead of writing things with the render
 const NormalRoute = ({ exact, path, component, ...componentProps }) => {
   const Component = component;
   return (
-    <Route
-      exact={exact}
-      path={path}
-      render={(props) => <Component {...componentProps} {...props} />}
-    />
+    <Routes>
+      <Route
+        exact={exact}
+        path={path}
+        element={<Component {...componentProps} {...props} />}
+      />
+    </Routes>
   );
 };
 

--- a/template/fullstack_hooks/auth/client/src/routing-components/ProtectedRoute.jsx
+++ b/template/fullstack_hooks/auth/client/src/routing-components/ProtectedRoute.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Route, Redirect } from "react-router-dom";
+import { Route, Navigate, Routes } from "react-router-dom";
 import * as PATHS from "../utils/paths";
 
 // the protected route component must take a user in order to check if the user is authenticated or not. If not moves the user to the login page
@@ -12,16 +12,18 @@ const ProtectedRoute = ({
 }) => {
   const Component = component;
   if (!user) {
-    return <Redirect to={PATHS.LOGINPAGE} />;
+    return <Navigate to={PATHS.LOGINPAGE} />;
   }
   return (
-    <Route
-      exact={exact}
-      path={path}
-      render={(props) => (
-        <Component {...componentProps} {...props} user={user} />
-      )}
-    />
+    <Routes>
+      <Route
+        exact={exact}
+        path={path}
+        render={(props) => (
+          <Component {...componentProps} {...props} user={user} />
+        )}
+      />
+    </Routes>
   );
 };
 


### PR DESCRIPTION
Adapt to react router dom v6: convert <Switch> elements to <Routes>; v6 favors elements over components and these take components (with tags) instead of objects; <Redirect> is no longer supported, instead it uses <Navigate>.
https://reactrouter.com/docs/en/v6/upgrading/v5#advantages-of-route-element